### PR TITLE
fix use of jquery with browserify

### DIFF
--- a/game.html
+++ b/game.html
@@ -24,8 +24,6 @@
 	<style type="text/css" media="all">@import "css/game.css";</style>
 	
 	<script type="text/javascript" src="./build/main.js"/></script>
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.1/jquery-ui.min.js"></script>
 </head>
 
 <body onkeyup="pressed_a_key(event)"; onLoad="start_game();">

--- a/javascript/game.js
+++ b/javascript/game.js
@@ -9,6 +9,8 @@
 	*/
 	
     require("./string_utils");
+    var $ = require('jquery');
+    require('jquery-ui');
 
     global.start_game = start_game;
     global.pressed_a_key = pressed_a_key;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-jasmine": "~0.8.1",
     "grunt-shell": "~1.1.1",
-    "jquery": "~2.1.1"
+    "jquery": "~2.1.1",
+    "jquery-ui": "~1.10.5"
   }
 }


### PR DESCRIPTION
realised we didn't fully modify the code to use the npm package, and were still loading the cdn versions.  this pull request ensures that we're using the same version for both specs and the game itself.  (you'll need to `npm install` if you merge this.)
